### PR TITLE
cartographer_ros/package.xml needs yaml-cpp

### DIFF
--- a/kinetic_maintainer_update/cartographer_ros/package.xml
+++ b/kinetic_maintainer_update/cartographer_ros/package.xml
@@ -66,6 +66,7 @@
   <depend>tf2_ros</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>rosunit</test_depend>
 

--- a/lunar_maintainer_update/cartographer_ros/package.xml
+++ b/lunar_maintainer_update/cartographer_ros/package.xml
@@ -66,6 +66,7 @@
   <depend>tf2_ros</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
which is defiend in upstream source tree, https://github.com/googlecartographer/cartographer_ros/blob/0.2.0/cartographer_ros/package.xml#L62 (so I just copied from wrong version)