### PR TITLE
[lunar] Force dep 0.2.0

### DIFF
--- a/lunar/cartographer_ros/package.xml
+++ b/lunar/cartographer_ros/package.xml
@@ -45,7 +45,7 @@
   <build_depend>protobuf-dev</build_depend>
   <build_depend>python-sphinx</build_depend>
 
-  <depend>cartographer</depend>
+  <depend version_lt="0.3.0">cartographer</depend>
   <depend>cartographer_ros_msgs</depend>
   <depend>eigen_conversions</depend>
   <depend>geometry_msgs</depend>

--- a/lunar/cartographer_ros/package.xml
+++ b/lunar/cartographer_ros/package.xml
@@ -23,6 +23,10 @@
     and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
     configurations. This package provides Cartographer's ROS integration.
   </description>
+
+  <maintainer email="cartographer-owners@googlegroups.com">
+    The Cartographer Owners
+  </maintainer>
   <maintainer email="mikael@osrfoundation.org">
     Mikael Arguedas
   </maintainer>

--- a/lunar/cartographer_ros/package.xml
+++ b/lunar/cartographer_ros/package.xml
@@ -32,7 +32,6 @@
   <maintainer email="ryosuke.tajima@opensource-robotics.tokyo.jp">
     Ryosuke Tajima
   </maintainer>
-  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/lunar/cartographer_ros_msgs/package.xml
+++ b/lunar/cartographer_ros_msgs/package.xml
@@ -31,7 +31,6 @@
   <maintainer email="ryosuke.tajima@opensource-robotics.tokyo.jp">
     Ryosuke Tajima
   </maintainer>
-  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/lunar/cartographer_ros_msgs/package.xml
+++ b/lunar/cartographer_ros_msgs/package.xml
@@ -22,6 +22,9 @@
     ROS messages for the cartographer_ros package.
   </description>
 
+  <maintainer email="cartographer-owners@googlegroups.com">
+    The Cartographer Owners
+  </maintainer>
   <maintainer email="mikael@osrfoundation.org">
     Mikael Arguedas
   </maintainer>

--- a/lunar/cartographer_rviz/package.xml
+++ b/lunar/cartographer_rviz/package.xml
@@ -23,6 +23,10 @@
     and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
     configurations. This package provides Cartographer's RViz integration.
   </description>
+
+  <maintainer email="cartographer-owners@googlegroups.com">
+    The Cartographer Owners
+  </maintainer>
   <maintainer email="mikael@osrfoundation.org">
     Mikael Arguedas
   </maintainer>

--- a/lunar/cartographer_rviz/package.xml
+++ b/lunar/cartographer_rviz/package.xml
@@ -32,7 +32,6 @@
   <maintainer email="ryosuke.tajima@opensource-robotics.tokyo.jp">
     Ryosuke Tajima
   </maintainer>
-  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/lunar/cartographer_rviz/package.xml
+++ b/lunar/cartographer_rviz/package.xml
@@ -42,7 +42,7 @@
 
   <build_depend>g++-static</build_depend>
 
-  <depend>cartographer</depend>
+  <depend version_lt="0.3.0">cartographer</depend>
   <depend>cartographer_ros</depend>
   <depend>cartographer_ros_msgs</depend>
   <depend>eigen_conversions</depend>


### PR DESCRIPTION
As cartographer 0.3.0 has been released in Lunar on Debian Stretch last december. We need to force cartographer to be below 0.3.0, this way, Debian users will be notified that they have an incompatible version and need to instal 0.2.0 from the ROS apt repositories. This fix should not be necessary for kinetic as we never released cartographer on kinetic

PS: I saw that I was listed twice as a maintainer in some package.xml and that Cartographer Owners was not listed so I updated where needed

Connects to https://github.com/ros-gbp/cartographer_ros-release/issues/4